### PR TITLE
Add Python language support to code-search agent

### DIFF
--- a/code-search/packages/code-agent/package.json
+++ b/code-search/packages/code-agent/package.json
@@ -23,6 +23,7 @@
     "simple-git": "^3.30.0",
     "tiktoken": "^1.0.22",
     "tree-sitter": "^0.25.0",
+    "tree-sitter-python": "^0.23.6",
     "tree-sitter-typescript": "^0.23.2",
     "uuid": "^13.0.0",
     "zod": "^3.25.76"

--- a/code-search/packages/code-agent/src/chunker/languages/index.ts
+++ b/code-search/packages/code-agent/src/chunker/languages/index.ts
@@ -1,9 +1,11 @@
 import { LanguageConfig } from "./types";
 import { tsxConfig, typescriptConfig } from "./typescript";
+import { pythonConfig } from "./python";
 
 export type { LanguageConfig } from "./types";
 
 export const languageConfigs: Record<string, LanguageConfig> = {
   ".ts": typescriptConfig,
   ".tsx": tsxConfig,
+  ".py": pythonConfig,
 };

--- a/code-search/packages/code-agent/src/chunker/languages/python.ts
+++ b/code-search/packages/code-agent/src/chunker/languages/python.ts
@@ -1,0 +1,16 @@
+import { LanguageConfig } from "./types";
+import Python from "tree-sitter-python";
+import { Language } from "tree-sitter";
+
+export const pythonConfig: LanguageConfig = {
+  language: () => Python as unknown as Language,
+  name: "python",
+  targetNodes: new Set<string>([
+    "function_definition",
+    "class_definition",
+    "decorated_definition",
+    "expression_statement",
+    "global_statement",
+    "if_statement",
+  ]),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       tree-sitter:
         specifier: ^0.25.0
         version: 0.25.0
+      tree-sitter-python:
+        specifier: ^0.23.6
+        version: 0.23.6(tree-sitter@0.25.0)
       tree-sitter-typescript:
         specifier: ^0.23.2
         version: 0.23.2(tree-sitter@0.25.0)
@@ -2183,6 +2186,14 @@ packages:
     resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
     peerDependencies:
       tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-python@0.23.6:
+    resolution: {integrity: sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
     peerDependenciesMeta:
       tree-sitter:
         optional: true
@@ -4477,6 +4488,13 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-sitter-javascript@0.23.1(tree-sitter@0.25.0):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.25.0
+
+  tree-sitter-python@0.23.6(tree-sitter@0.25.0):
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,4 +13,5 @@ onlyBuiltDependencies:
   - sharp
   - tree-sitter
   - tree-sitter-javascript
+  - tree-sitter-python
   - tree-sitter-typescript


### PR DESCRIPTION
Enable .py file ingestion by adding a tree-sitter-python language config targeting function_definition, class_definition, decorated_definition, expression_statement, global_statement, and if_statement AST nodes. Python chunks are indexed into the same ChromaDB collection as TypeScript for mixed-language semantic search.